### PR TITLE
repair ZoomOut click event bug

### DIFF
--- a/ViewPagerTransformsLibrary/src/com/ToxicBakery/viewpager/transforms/ZoomOutTranformer.java
+++ b/ViewPagerTransformsLibrary/src/com/ToxicBakery/viewpager/transforms/ZoomOutTranformer.java
@@ -12,6 +12,9 @@ public class ZoomOutTranformer extends ABaseTransformer {
 		view.setPivotX(view.getWidth() * 0.5f);
 		view.setPivotY(view.getHeight() * 0.5f);
 		view.setAlpha(position < -1f || position > 1f ? 0f : 1f - (scale - 1f));
+		if(position == -1){
+			view.setTranslationX(view.getWidth() * -1);
+		}
 	}
 
 }


### PR DESCRIPTION
int zoom out transformer
when the previous slider zoom out, it still on the above layer of current slide ( just transparent ). When you want to  catch the click event, the previous slider will get it instead of current.

So, we have to do another thing to make it disappear. move it to the left.

(I 'm not  sure if i describe it clear. you can try to add click event to each slider , and to see it ) 
:-D
