### PR TITLE
Issue 55 rename zoom out tranformer

### DIFF
--- a/app/src/main/java/com/ToxicBakery/viewpager/transforms/example/MainActivity.java
+++ b/app/src/main/java/com/ToxicBakery/viewpager/transforms/example/MainActivity.java
@@ -49,7 +49,7 @@ import com.ToxicBakery.viewpager.transforms.StackTransformer;
 import com.ToxicBakery.viewpager.transforms.TabletTransformer;
 import com.ToxicBakery.viewpager.transforms.ZoomInTransformer;
 import com.ToxicBakery.viewpager.transforms.ZoomOutSlideTransformer;
-import com.ToxicBakery.viewpager.transforms.ZoomOutTranformer;
+import com.ToxicBakery.viewpager.transforms.ZoomOutTransformer;
 
 public class MainActivity extends Activity implements OnNavigationListener {
 
@@ -75,7 +75,7 @@ public class MainActivity extends Activity implements OnNavigationListener {
         TRANSFORM_CLASSES.add(new TransformerItem(TabletTransformer.class));
         TRANSFORM_CLASSES.add(new TransformerItem(ZoomInTransformer.class));
         TRANSFORM_CLASSES.add(new TransformerItem(ZoomOutSlideTransformer.class));
-        TRANSFORM_CLASSES.add(new TransformerItem(ZoomOutTranformer.class));
+        TRANSFORM_CLASSES.add(new TransformerItem(ZoomOutTransformer.class));
     }
 
     private int mSelectedItem;

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.2.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 16 17:05:13 EST 2015
+#Mon Feb 13 10:48:57 GMT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/library/src/main/java/com/ToxicBakery/viewpager/transforms/ZoomOutTransformer.java
+++ b/library/src/main/java/com/ToxicBakery/viewpager/transforms/ZoomOutTransformer.java
@@ -18,7 +18,7 @@ package com.ToxicBakery.viewpager.transforms;
 
 import android.view.View;
 
-public class ZoomOutTranformer extends ABaseTransformer {
+public class ZoomOutTransformer extends ABaseTransformer {
 
 	@Override
 	protected void onTransform(View view, float position) {


### PR DESCRIPTION
Fixes #55 
renamed ZoomOutTranformer to ZoomOutTransformer 
updating gradle plugin to 2.2.3 (can drop this before Pull if you like)