### PR TITLE
Fixed issue on Android 4 where position was outside of the -1f..1f boundaries 

### DIFF
--- a/library/src/main/java/com/ToxicBakery/viewpager/transforms/ABaseTransformer.java
+++ b/library/src/main/java/com/ToxicBakery/viewpager/transforms/ABaseTransformer.java
@@ -44,27 +44,28 @@ public abstract class ABaseTransformer implements PageTransformer {
 	 */
 	@Override
 	public void transformPage(View page, float position) {
-		float flooredPosition = floorPosition(position);
+		float clampedPosition = clampPosition(position);
 
-		onPreTransform(page, flooredPosition);
-		onTransform(page, flooredPosition);
-		onPostTransform(page, flooredPosition);
+		onPreTransform(page, clampedPosition);
+		onTransform(page, clampedPosition);
+		onPostTransform(page, clampedPosition);
 	}
 
-    /**
-     * Floor the position. This step is required for some Android 4 devices.
-     * The position is dependant on the range of the ViewPager and whether it supports infinite scrolling in both directions.
-     * @param position Position of page relative to the current front-and-center position of the pager.
-     * @return A value between -1 and 1
-     */
-    private float floorPosition(float position) {
-        if (position < -1f) {
-            return -1f;
-        } else if (position > 1f) {
-            return 1f;
-        }
-        return position;
-    }
+	/**
+	 * Clamp the position. This step is required for some Android 4 devices.
+	 * The position is dependant on the range of the ViewPager and whether it supports infinite scrolling in both directions.
+	 *
+	 * @param position Position of page relative to the current front-and-center position of the pager.
+	 * @return A value between -1 and 1
+	 */
+	private float clampPosition(float position) {
+		if (position < -1f) {
+			return -1f;
+		} else if (position > 1f) {
+			return 1f;
+		}
+		return position;
+	}
 
 	/**
 	 * If the position offset of a fragment is less than negative one or greater than one, returning true will set the

--- a/library/src/main/java/com/ToxicBakery/viewpager/transforms/ABaseTransformer.java
+++ b/library/src/main/java/com/ToxicBakery/viewpager/transforms/ABaseTransformer.java
@@ -23,7 +23,7 @@ public abstract class ABaseTransformer implements PageTransformer {
 
 	/**
 	 * Called each {@link #transformPage(android.view.View, float)}.
-	 * 
+	 *
 	 * @param page
 	 *            Apply the transformation to this page
 	 * @param position
@@ -35,7 +35,7 @@ public abstract class ABaseTransformer implements PageTransformer {
 	/**
 	 * Apply a property transformation to the given page. For most use cases, this method should not be overridden.
 	 * Instead use {@link #transformPage(android.view.View, float)} to perform typical transformations.
-	 * 
+	 *
 	 * @param page
 	 *            Apply the transformation to this page
 	 * @param position
@@ -44,15 +44,32 @@ public abstract class ABaseTransformer implements PageTransformer {
 	 */
 	@Override
 	public void transformPage(View page, float position) {
-		onPreTransform(page, position);
-		onTransform(page, position);
-		onPostTransform(page, position);
+		float flooredPosition = floorPosition(position);
+
+		onPreTransform(page, flooredPosition);
+		onTransform(page, flooredPosition);
+		onPostTransform(page, flooredPosition);
 	}
+
+    /**
+     * Floor the position. This step is required for some Android 4 devices.
+     * The position is dependant on the range of the ViewPager and whether it supports infinite scrolling in both directions.
+     * @param position Position of page relative to the current front-and-center position of the pager.
+     * @return A value between -1 and 1
+     */
+    private float floorPosition(float position) {
+        if (position < -1f) {
+            return -1f;
+        } else if (position > 1f) {
+            return 1f;
+        }
+        return position;
+    }
 
 	/**
 	 * If the position offset of a fragment is less than negative one or greater than one, returning true will set the
 	 * fragment alpha to 0f. Otherwise fragment alpha is always defaulted to 1f.
-	 * 
+	 *
 	 * @return
 	 */
 	protected boolean hideOffscreenPages() {
@@ -61,7 +78,7 @@ public abstract class ABaseTransformer implements PageTransformer {
 
 	/**
 	 * Indicates if the default animations of the view pager should be used.
-	 * 
+	 *
 	 * @return
 	 */
 	protected boolean isPagingEnabled() {
@@ -75,7 +92,7 @@ public abstract class ABaseTransformer implements PageTransformer {
 	 * not modify the same page properties. For instance changing from a transformation that applies rotation to a
 	 * transformation that fades can inadvertently leave a fragment stuck with a rotation or with some degree of applied
 	 * alpha.
-	 * 
+	 *
 	 * @param page
 	 *            Apply the transformation to this page
 	 * @param position
@@ -106,7 +123,7 @@ public abstract class ABaseTransformer implements PageTransformer {
 
 	/**
 	 * Called each {@link #transformPage(android.view.View, float)} after {@link #onTransform(android.view.View, float)}.
-	 * 
+	 *
 	 * @param page
 	 *            Apply the transformation to this page
 	 * @param position
@@ -118,7 +135,7 @@ public abstract class ABaseTransformer implements PageTransformer {
 
 	/**
 	 * Same as {@link Math#min(double, double)} without double casting, zero closest to infinity handling, or NaN support.
-	 * 
+	 *
 	 * @param val
 	 * @param min
 	 * @return


### PR DESCRIPTION
This issue is quite specific to our project. We use a continuous scrolling ViewPager with an infinite amount of pages. 

Somehow the position retrieved in the 'transformPage' method exceed the boundaries on Android 4. This causes messed up animations where the wrong view animated which causes you to get stuck.

This fix makes sure that the position is always within it's boundaries and does not change any behaviour for working implementations. 