### PR TITLE
Kotlin upgrade and scaleX if the clamp is NaN fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     ext.android_target_sdk = 28
     ext.android_build_tools_version = '28.0.3'
 
-    ext.kotlin_version = '1.3.11'
+    ext.kotlin_version = '1.3.50'
     ext.jacoco_version = '0.8.1'
     ext.dokka_version = '0.9.17'
 
@@ -31,7 +31,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.5.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokka_version"
         classpath 'digital.wup:android-maven-publish:3.6.2'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sat Nov 02 19:53:49 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/library/src/main/java/com/ToxicBakery/viewpager/transforms/ABaseTransformer.kt
+++ b/library/src/main/java/com/ToxicBakery/viewpager/transforms/ABaseTransformer.kt
@@ -63,6 +63,8 @@ abstract class ABaseTransformer : PageTransformer {
      * The position is dependant on the range of the ViewPager and whether it supports infinite scrolling in both
      * directions.
      *
+     * On some devices it returns the position as NaN, so we set 0 as the fallback value
+     *
      * @param position Position of page relative to the current front-and-center position of the pager.
      * @return A value between -1 and 1
      */
@@ -70,6 +72,7 @@ abstract class ABaseTransformer : PageTransformer {
         return when {
             position < -1f -> -1f
             position > 1f -> 1f
+            position.isNaN() -> 0f
             else -> position
         }
     }


### PR DESCRIPTION
Fatal Exception: java.lang.IllegalArgumentException: Cannot set 'scaleX' to Float.NaN so if the clamped position is NaN we set it as 0 as the later on implementations take care of that.

Also updated kotlin to 1.3.50 and gradle plugin